### PR TITLE
feat: add Sumak adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,11 @@ You'll also need to install the specific database driver or ORM you plan to use.
     <td>For Knex SQL query builder</td>
     <td>✅ Ready</td>
   </tr>
+  <tr>
+    <td><b><a href="https://github.com/productdevbook/sumak">Sumak Adapter</a></b></td>
+    <td>For Sumak — type-safe, AST-first SQL query builder</td>
+    <td>✅ Ready</td>
+  </tr>
 </table>
 
 ## 🚀 Getting Started
@@ -959,6 +964,96 @@ await (await getMigrations({ database: knexAdapter(db, { type: "postgres" }), ..
 
 </details>
 
+<details>
+<summary><b>Sumak Adapter Example</b></summary>
+
+```typescript
+import type { PluginSchema } from "unadapter/types"
+import { createAdapter, createTable, mergePluginSchemas } from "unadapter"
+import { Pool } from "pg"
+import { pgDialect, sumak } from "sumak"
+import { pgDriver } from "sumak/drivers/pg"
+import { sumakAdapter } from "unadapter/sumak"
+
+// Create a sumak instance with an attached driver. Tables can be
+// defined statically here (sumak's typed builders) or left empty when
+// schema is purely runtime-driven via unadapter's TablesSchema.
+const pool = new Pool({ connectionString: "postgres://user:pass@localhost/app" })
+const db = sumak({
+  dialect: pgDialect(),
+  driver: pgDriver(pool),
+  tables: {},
+})
+
+interface CustomOptions {
+  appName?: string
+  plugins?: { schema?: PluginSchema }[]
+  user?: {
+    fields?: {
+      name?: string
+      email?: string
+    }
+  }
+}
+
+const tables = createTable<CustomOptions>((options) => {
+  const { user, ...pluginTables } = mergePluginSchemas<CustomOptions>(options) || {}
+  return {
+    user: {
+      modelName: "user",
+      fields: {
+        name: {
+          type: "string",
+          required: true,
+          fieldName: options?.user?.fields?.name || "name",
+        },
+        email: {
+          type: "string",
+          required: true,
+          unique: true,
+          fieldName: options?.user?.fields?.email || "email",
+        },
+        createdAt: {
+          type: "date",
+          defaultValue: () => new Date(),
+          fieldName: "created_at",
+        },
+        ...user?.fields,
+        ...options?.user?.fields,
+      },
+    },
+  }
+})
+
+const adapter = createAdapter(tables, {
+  database: sumakAdapter(db, {
+    type: "postgres", // "postgres" | "mysql" | "sqlite" | "mssql"
+  }),
+  plugins: [],
+})
+
+const user = await adapter.create({
+  model: "user",
+  data: {
+    name: "Ada Lovelace",
+    email: "ada@example.com",
+  },
+})
+```
+
+The Sumak adapter ships its own migrator (uses `db.schema` DDL builders
+
+- `introspect()`), so you can drive migrations through `getMigrations`:
+
+```typescript
+import { getMigrations } from "unadapter/db"
+
+await (await getMigrations({ database: sumakAdapter(db, { type: "postgres" }), ... }, tables))
+  .runMigrations()
+```
+
+</details>
+
 ## 🛠️ Migrations
 
 `getMigrations()` is adapter-agnostic. Each adapter contributes its own
@@ -969,6 +1064,7 @@ using its native schema API:
 | ------- | -------- | ------------------------------------------------------------------ |
 | Kysely  | ✅       | Backwards-compatible: also accepts a raw Dialect / pool / DB shape |
 | Knex    | ✅       | Uses `knex.schema` + `information_schema` / SQLite `PRAGMA`        |
+| Sumak   | ✅       | Uses `db.schema` (DDL builders) + sumak's `introspect()`           |
 | Drizzle | ❌       | Use `drizzle-kit` for schema management                            |
 | Prisma  | ❌       | Use Prisma Migrate / `prisma db push`                              |
 | MongoDB | n/a      | Schemaless                                                         |

--- a/README.md
+++ b/README.md
@@ -1095,56 +1095,47 @@ All adapters implement the following interface:
 
 ```typescript
 interface Adapter {
+  // Identifies which adapter implementation this is (e.g. "kysely", "knex").
+  id: string
+
   // Create a new record
-  create<T>({
-    model: string,
-    data: Omit<T, 'id'>,
-    select?: string[]
-  }): Promise<T>;
+  create<T>(args: { model: string; data: Omit<T, "id">; select?: string[] }): Promise<T>
+
+  // Find one record
+  findOne<T>(args: { model: string; where: Where[]; select?: string[] }): Promise<T | null>
 
   // Find multiple records
-  findMany<T>({
-    model: string,
-    where?: Where[],
-    limit?: number,
-    sortBy?: {
-      field: string,
-      direction: 'asc' | 'desc'
-    },
+  findMany<T>(args: {
+    model: string
+    where?: Where[]
+    limit?: number
+    sortBy?: { field: string; direction: "asc" | "desc" }
     offset?: number
-  }): Promise<T[]>;
+    select?: string[]
+  }): Promise<T[]>
 
   // Update a record
-  update<T>({
-    model: string,
-    where: Where[],
-    update: Record<string, any>
-  }): Promise<T | null>;
+  update<T>(args: { model: string; where: Where[]; update: Partial<T> }): Promise<T | null>
 
-  // Update multiple records
-  updateMany({
-    model: string,
-    where: Where[],
-    update: Record<string, any>
-  }): Promise<number>;
+  // Update multiple records — returns affected row count
+  updateMany(args: { model: string; where: Where[]; update: Record<string, any> }): Promise<number>
 
   // Delete a record
-  delete({
-    model: string,
-    where: Where[]
-  }): Promise<void>;
+  delete(args: { model: string; where: Where[] }): Promise<void>
 
-  // Delete multiple records
-  deleteMany({
-    model: string,
-    where: Where[]
-  }): Promise<number>;
+  // Delete multiple records — returns affected row count
+  deleteMany(args: { model: string; where: Where[] }): Promise<number>
 
   // Count records
-  count({
-    model: string,
-    where?: Where[]
-  }): Promise<number>;
+  count(args: { model: string; where?: Where[] }): Promise<number>
+
+  // Optional: run a callback inside a database transaction. Adapters
+  // that don't support isolation get a no-op fallback that still
+  // exposes the same surface.
+  transaction?<R>(cb: (tx: Adapter) => Promise<R>): Promise<R>
+
+  // Optional: build an adapter-native migrator (see Migrations).
+  createMigrator?(): Promise<AdapterMigrator> | AdapterMigrator
 }
 ```
 
@@ -1182,38 +1173,159 @@ interface Where {
 When defining your schema, you can use the following field types and attributes:
 
 ```typescript
-interface FieldAttribute {
-  // The type of the field
-  type: "string" | "number" | "boolean" | "date" | "json" | "array"
+type FieldType =
+  | "string"
+  | "number"
+  | "boolean"
+  | "date"
+  | "json" // jsonb on Postgres, json on MySQL, text on SQLite
+  | "string[]" // jsonb / text array
+  | "number[]" // jsonb / text array
+  | LiteralString[] // enum-style: e.g. ["pending", "active", "archived"]
 
-  // Whether this field is required
+interface FieldAttribute {
+  type: FieldType
+
+  // Whether this field is required (default: true)
   required?: boolean
 
   // Whether this field should be unique
   unique?: boolean
 
-  // The actual column/field name in the database
-  fieldName?: string
+  // Whether to emit a database-level index (`<table>_<field>_idx`).
+  // Combined with `unique` becomes CREATE UNIQUE INDEX.
+  index?: boolean
 
-  // Whether this field can be sorted
+  // For number fields, store as BIGINT instead of INTEGER.
+  bigint?: boolean
+
+  // Whether this field can be sorted (hints VARCHAR sizing on MySQL/MSSQL).
   sortable?: boolean
 
-  // Default value function
-  defaultValue?: () => any
+  // Whether the field should be returned to the client (used by toZodSchema).
+  returned?: boolean
 
-  // Reference to another model (for foreign keys)
+  // Whether the client may supply this field on input (used by toZodSchema).
+  input?: boolean
+
+  // The actual column/field name in the database.
+  fieldName?: string
+
+  // Default value used by the framework on insert. Plain values stay
+  // caller-side; for `date` columns a function defaultValue maps to a
+  // server-side `CURRENT_TIMESTAMP` default in DDL.
+  defaultValue?: Primitive | (() => Primitive)
+
+  // Reference to another model (for foreign keys).
   references?: {
     model: string
     field: string
-    onDelete?: "cascade" | "set null" | "restrict"
+    onDelete?: "no action" | "restrict" | "cascade" | "set null" | "set default"
   }
 
-  // Custom transformations
+  // Custom transformations applied around adapter input/output.
   transform?: {
-    input?: (value: any) => any
-    output?: (value: any) => any
+    input?: (value: any) => any | Promise<any>
+    output?: (value: any) => any | Promise<any>
+  }
+
+  // Standard Schema-compatible validator (Zod, Valibot, ArkType, …).
+  validator?: {
+    input?: StandardSchemaLike
+    output?: StandardSchemaLike
   }
 }
+```
+
+</details>
+
+<details>
+<summary><b>ID Generation Strategies</b></summary>
+
+`advanced.database.generateId` controls how primary keys are produced:
+
+```typescript
+const adapter = createAdapter(tables, {
+  database: kyselyAdapter(db, { type: "postgres" }),
+  advanced: {
+    database: {
+      // Pick one of:
+      // generateId: () => crypto.randomUUID(),  // function: caller-supplied
+      // generateId: false,                      // let the DB auto-generate
+      // generateId: "uuid",                     // PG: gen_random_uuid()
+      // generateId: "serial",                   // PG: GENERATED BY DEFAULT AS IDENTITY
+      // useNumberId: true,                      // legacy: integer auto-increment
+    },
+  },
+})
+```
+
+| Strategy            | Type               | Default produced by                        |
+| ------------------- | ------------------ | ------------------------------------------ |
+| (default)           | string             | `crypto.randomUUID()` in JS at insert time |
+| function            | string             | The caller's function                      |
+| `false`             | (any)              | Database column default                    |
+| `"uuid"`            | uuid / varchar(36) | PG `gen_random_uuid()` server default      |
+| `"serial"`          | integer            | PG `GENERATED BY DEFAULT AS IDENTITY`      |
+| `useNumberId: true` | integer            | Dialect's auto-increment / serial          |
+
+</details>
+
+<details>
+<summary><b>Helpers (`unadapter/db`)</b></summary>
+
+```typescript
+import {
+  toZodSchema, // Build a Zod schema from a fields record
+  convertToDB, // Map { logicalKey: value } → { fieldName: value }
+  convertFromDB, // Inverse of convertToDB
+  getMigrations, // Run / compile schema migrations
+} from "unadapter/db"
+
+// Schema → Zod (drops `returned: false` server-side, `input: false` client-side)
+const schema = toZodSchema({ fields: tables.user.fields, isClientSide: true })
+schema.parse({ name: "Ada", email: "ada@example.com" })
+
+// fieldName-aware mapping for adapters that bypass createAdapterFactory
+const dbRow = convertToDB(tables.user.fields, { name: "Ada", email: "ada@example.com" })
+const logical = convertFromDB(tables.user.fields, dbRow)
+```
+
+```typescript
+import { createAdapterFactory } from "unadapter/create"
+
+// Canonical name — `createAdapter` (factory form) is a deprecated alias.
+export function myAdapter(db, config) {
+  return createAdapterFactory({
+    config: { adapterId: "my-adapter", supportsJSON: true, supportsDates: true },
+    adapter: ({ getFieldName, schema }) => ({
+      create: async ({ model, data }) => {
+        /* ... */
+      },
+      findOne: async ({ model, where }) => {
+        /* ... */
+      },
+      // ... rest of CustomAdapter contract
+    }),
+  })
+}
+```
+
+</details>
+
+<details>
+<summary><b>Transactions</b></summary>
+
+Adapters that support isolation expose `adapter.transaction(cb)`. Inside
+the callback you receive a transactional adapter with the same surface
+as the outer one. Adapters that can't isolate (memory, mongodb without
+sessions) get a no-op fallback so you can write the same code path:
+
+```typescript
+await adapter.transaction(async (tx) => {
+  const user = await tx.create({ model: "user", data: { name: "Ada" } })
+  await tx.create({ model: "audit", data: { userId: user.id, action: "signup" } })
+})
 ```
 
 </details>

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "kysely",
     "mongodb",
     "prisma",
+    "sumak",
     "unadapter"
   ],
   "homepage": "https://github.com/productdevbook/unadapter#readme",
@@ -59,6 +60,10 @@
     "./prisma": {
       "types": "./dist/adapters/prisma/index.d.mts",
       "import": "./dist/adapters/prisma/index.mjs"
+    },
+    "./sumak": {
+      "types": "./dist/adapters/sumak/index.d.mts",
+      "import": "./dist/adapters/sumak/index.mjs"
     },
     "./create": {
       "types": "./dist/adapters/create/index.d.mts",
@@ -120,6 +125,7 @@
     "oxlint": "^1.62.0",
     "pg": "^8.20.0",
     "prisma": "^6.7.0",
+    "sumak": "^0.0.14",
     "tarn": "^3.0.2",
     "tedious": "^19.2.1",
     "typescript": "^6.0.3",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       prisma:
         specifier: ^6.7.0
         version: 6.19.3(typescript@6.0.3)
+      sumak:
+        specifier: ^0.0.14
+        version: 0.0.14
       tarn:
         specifier: ^3.0.2
         version: 3.0.2
@@ -1946,6 +1949,10 @@ packages:
     resolution: {integrity: sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==}
     engines: {node: '>=0.10.0'}
 
+  sumak@0.0.14:
+    resolution: {integrity: sha512-CAoBjeryJkKpvBb2KYrVeOJ6Zl689DSjXux+GvwPSYbnWAuMrTVj1OF1NmHIRPgxaS+0IIxpmY2FZSc3HLG3YA==}
+    hasBin: true
+
   supports-color@7.2.0:
     resolution: {integrity: sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==}
     engines: {node: '>=8'}
@@ -3730,6 +3737,8 @@ snapshots:
       safe-buffer: 5.2.1
 
   strip-json-comments@2.0.1: {}
+
+  sumak@0.0.14: {}
 
   supports-color@7.2.0:
     dependencies:

--- a/src/adapters/sumak/index.ts
+++ b/src/adapters/sumak/index.ts
@@ -1,0 +1,3 @@
+export * from "./migrator.ts"
+export * from "./sumak-adapter.ts"
+export * from "./types.ts"

--- a/src/adapters/sumak/migrator.ts
+++ b/src/adapters/sumak/migrator.ts
@@ -129,9 +129,10 @@ function applyColumnDef(builder: any, column: ColumnDefinition, isPrimaryKey: bo
     b = b.references(column.references.table, column.references.field)
   }
   if (column.defaultExpr) {
-    // DDLPrinter only accepts certain expression node shapes — `sql.unsafe()`
-    // produces a raw fragment that DDL printers can render verbatim.
-    b = b.defaultTo(sql.unsafe(column.defaultExpr))
+    // ColumnDefBuilder.defaultTo wants a raw ExpressionNode, not the
+    // wrapped Expression that sql.unsafe() returns. Unwrap `.node`.
+    const expr: any = sql.unsafe(column.defaultExpr)
+    b = b.defaultTo(expr.node ?? expr)
   }
   if (isPrimaryKey) {
     if (column.autoIncrement) b = b.autoIncrement()

--- a/src/adapters/sumak/migrator.ts
+++ b/src/adapters/sumak/migrator.ts
@@ -162,11 +162,12 @@ export function createSumakMigratorFromSumak(opts: SumakMigratorOptions): Adapte
 
   return {
     async introspect(): Promise<TableInfo[]> {
-      const driver = (db as any)._driver ?? (db as any).driver
+      // `db.driver` is a method that throws when no driver is configured;
+      // `driverOrNull()` returns undefined instead, which is what we want
+      // for the "no live DB to inspect → engine treats every table as new"
+      // path.
+      const driver: any = (db as any).driverOrNull?.()
       if (!driver) {
-        // Without a driver attached we can't introspect — return empty
-        // so the engine treats every schema entry as new (idempotent on
-        // re-runs against an empty database).
         return []
       }
       const schema = await introspect(driver, sumakDialectName)

--- a/src/adapters/sumak/migrator.ts
+++ b/src/adapters/sumak/migrator.ts
@@ -9,7 +9,7 @@ import type {
   TableInfo,
 } from "../../types/index.ts"
 import type { SumakDatabaseType } from "./types.ts"
-import { introspect, unsafeRawExpr } from "sumak"
+import { introspect, sql } from "sumak"
 
 const dialectTypeMap: Record<SumakDatabaseType, Record<string, string[]>> = {
   postgres: {
@@ -129,7 +129,9 @@ function applyColumnDef(builder: any, column: ColumnDefinition, isPrimaryKey: bo
     b = b.references(column.references.table, column.references.field)
   }
   if (column.defaultExpr) {
-    b = b.defaultTo(unsafeRawExpr(column.defaultExpr))
+    // DDLPrinter only accepts certain expression node shapes — `sql.unsafe()`
+    // produces a raw fragment that DDL printers can render verbatim.
+    b = b.defaultTo(sql.unsafe(column.defaultExpr))
   }
   if (isPrimaryKey) {
     if (column.autoIncrement) b = b.autoIncrement()

--- a/src/adapters/sumak/migrator.ts
+++ b/src/adapters/sumak/migrator.ts
@@ -1,0 +1,236 @@
+import type { Sumak } from "sumak"
+import type {
+  AdapterMigrator,
+  ColumnDefinition,
+  FieldAttribute,
+  FieldType,
+  IndexDefinition,
+  MigratorOptions,
+  TableInfo,
+} from "../../types/index.ts"
+import type { SumakDatabaseType } from "./types.ts"
+import { introspect, unsafeRawExpr } from "sumak"
+
+const dialectTypeMap: Record<SumakDatabaseType, Record<string, string[]>> = {
+  postgres: {
+    string: ["character varying", "text"],
+    number: ["int4", "integer", "bigint", "smallint", "numeric", "real", "double precision"],
+    boolean: ["bool", "boolean"],
+    date: ["timestamp", "timestamp with time zone", "date"],
+    json: ["json", "jsonb"],
+  },
+  mysql: {
+    string: ["varchar", "text"],
+    number: ["integer", "int", "bigint", "smallint", "decimal", "float", "double"],
+    boolean: ["boolean", "tinyint"],
+    date: ["timestamp", "datetime", "date"],
+    json: ["json"],
+  },
+  sqlite: {
+    string: ["TEXT"],
+    number: ["INTEGER", "REAL"],
+    boolean: ["INTEGER", "BOOLEAN"],
+    date: ["DATE", "INTEGER"],
+    json: ["TEXT"],
+  },
+  mssql: {
+    string: ["text", "varchar"],
+    number: ["int", "bigint", "smallint", "decimal", "float", "double"],
+    boolean: ["bit", "smallint"],
+    date: ["datetime", "date"],
+    json: ["varchar", "text"],
+  },
+}
+
+function resolveType(
+  field: FieldAttribute,
+  fieldName: string,
+  options: MigratorOptions,
+  dialect: SumakDatabaseType,
+): string {
+  const isIdLike = fieldName === "id" || field.references?.field === "id"
+  if (isIdLike) {
+    switch (options.idStrategy) {
+      case "number":
+        return dialect === "postgres" ? "serial" : "integer"
+      case "serial":
+        return "integer"
+      case "uuid":
+        return dialect === "postgres" ? "uuid" : "varchar(36)"
+      case "string":
+      default:
+        return dialect === "sqlite" || dialect === "postgres" ? "text" : "varchar(36)"
+    }
+  }
+
+  const type = field.type
+  if (type === "json") {
+    if (dialect === "postgres") return "jsonb"
+    if (dialect === "mysql") return "json"
+    if (dialect === "mssql") return "varchar(8000)"
+    return "text"
+  }
+  if (dialect === "sqlite" && (type === "string[]" || type === "number[]")) {
+    return "text"
+  }
+  if (type === "string[]" || type === "number[]") {
+    return "jsonb"
+  }
+  if (Array.isArray(type)) {
+    return "text"
+  }
+
+  switch (type) {
+    case "string":
+      if (dialect === "mysql") {
+        return field.unique ? "varchar(255)" : field.references ? "varchar(36)" : "text"
+      }
+      if (dialect === "mssql") {
+        return field.unique || field.sortable
+          ? "varchar(255)"
+          : field.references
+            ? "varchar(36)"
+            : "text"
+      }
+      return "text"
+    case "boolean":
+      if (dialect === "sqlite") return "integer"
+      if (dialect === "mssql") return "smallint"
+      return "boolean"
+    case "number":
+      return field.bigint ? "bigint" : "integer"
+    case "date":
+      if (dialect === "sqlite") return "date"
+      if (dialect === "postgres") return "timestamp"
+      return "datetime"
+  }
+  return "text"
+}
+
+function matchType(
+  columnDataType: string,
+  fieldType: FieldType,
+  dialect: SumakDatabaseType,
+): boolean {
+  if (fieldType === "string[]" || fieldType === "number[]") {
+    return columnDataType.toLowerCase().includes("json")
+  }
+  const types = dialectTypeMap[dialect]
+  const lookup = (Array.isArray(fieldType) ? types.string : types[fieldType]) || []
+  const acceptable = lookup.map((t) => t.toLowerCase())
+  return acceptable.includes(columnDataType.toLowerCase())
+}
+
+function applyColumnDef(builder: any, column: ColumnDefinition, isPrimaryKey: boolean): any {
+  let b = builder
+  if (column.notNull) b = b.notNull()
+  if (column.unique) b = b.unique()
+  if (column.references) {
+    b = b.references(column.references.table, column.references.field)
+  }
+  if (column.defaultExpr) {
+    b = b.defaultTo(unsafeRawExpr(column.defaultExpr))
+  }
+  if (isPrimaryKey) {
+    if (column.autoIncrement) b = b.autoIncrement()
+    b = b.primaryKey()
+  }
+  return b
+}
+
+function indexName(index: IndexDefinition): string {
+  return `${index.table}_${index.field}_idx`
+}
+
+export interface SumakMigratorOptions {
+  db: Sumak<any>
+  dialect: SumakDatabaseType
+}
+
+/**
+ * Sumak-driven migrator. Schema introspection comes from sumak's
+ * built-in `introspect()` helper (works against any dialect's driver),
+ * DDL is emitted via the `db.schema` builders + `executeCompiledNoRows`.
+ */
+export function createSumakMigratorFromSumak(opts: SumakMigratorOptions): AdapterMigrator {
+  const { db, dialect } = opts
+  const sumakDialectName: "pg" | "mysql" | "sqlite" | "mssql" =
+    dialect === "postgres" ? "pg" : dialect
+
+  return {
+    async introspect(): Promise<TableInfo[]> {
+      const driver = (db as any)._driver ?? (db as any).driver
+      if (!driver) {
+        // Without a driver attached we can't introspect — return empty
+        // so the engine treats every schema entry as new (idempotent on
+        // re-runs against an empty database).
+        return []
+      }
+      const schema = await introspect(driver, sumakDialectName)
+      return schema.tables.map((t) => ({
+        name: t.name,
+        columns: t.columns.map((c) => ({ name: c.name, dataType: c.dataType })),
+      }))
+    },
+
+    async createTable(table, idColumn, fields, _options): Promise<void> {
+      let b = (db as any).schema.createTable(table)
+      b = b.addColumn("id", idColumn.type, (col: any) => applyColumnDef(col, idColumn, true))
+      for (const [fieldName, column] of Object.entries(fields)) {
+        b = b.addColumn(fieldName, column.type, (col: any) => applyColumnDef(col, column, false))
+      }
+      const node = b.build()
+      const compiled = (db as any).compileDDL(node)
+      await (db as any).executeCompiledNoRows(compiled)
+    },
+
+    async addColumn(table, name, column, _options): Promise<void> {
+      const node = (db as any).schema
+        .alterTable(table)
+        .addColumn(name, column.type, (col: any) => applyColumnDef(col, column, false))
+        .build()
+      const compiled = (db as any).compileDDL(node)
+      await (db as any).executeCompiledNoRows(compiled)
+    },
+
+    async createIndex(index): Promise<void> {
+      let b = (db as any).schema.createIndex(indexName(index)).on(index.table).column(index.field)
+      if (index.unique) b = b.unique()
+      const node = b.build()
+      const compiled = (db as any).compileDDL(node)
+      await (db as any).executeCompiledNoRows(compiled)
+    },
+
+    resolveType(field, fieldName, options): string {
+      return resolveType(field, fieldName, options, dialect)
+    },
+
+    matchType(columnDataType, fieldType): boolean {
+      return matchType(columnDataType, fieldType, dialect)
+    },
+
+    compileCreateTable(table, idColumn, fields, _options): string {
+      let b = (db as any).schema.createTable(table)
+      b = b.addColumn("id", idColumn.type, (col: any) => applyColumnDef(col, idColumn, true))
+      for (const [fieldName, column] of Object.entries(fields)) {
+        b = b.addColumn(fieldName, column.type, (col: any) => applyColumnDef(col, column, false))
+      }
+      const node = b.build()
+      return (db as any).compileDDL(node).sql
+    },
+
+    compileAddColumn(table, name, column, _options): string {
+      const node = (db as any).schema
+        .alterTable(table)
+        .addColumn(name, column.type, (col: any) => applyColumnDef(col, column, false))
+        .build()
+      return (db as any).compileDDL(node).sql
+    },
+
+    compileCreateIndex(index): string {
+      let b = (db as any).schema.createIndex(indexName(index)).on(index.table).column(index.field)
+      if (index.unique) b = b.unique()
+      return (db as any).compileDDL(b.build()).sql
+    },
+  }
+}

--- a/src/adapters/sumak/sumak-adapter.ts
+++ b/src/adapters/sumak/sumak-adapter.ts
@@ -203,8 +203,11 @@ export function sumakAdapter<
             }
             return null
           }
-          let q: any = (db as any).update(model).set(values).returningAll()
+          // Sumak's UpdateBuilder requires `.where(...)` before `.returningAll()` —
+          // returningAll() narrows to a returning-builder that doesn't expose where.
+          let q: any = (db as any).update(model).set(values)
           if (cb) q = q.where(cb)
+          q = q.returningAll()
           const rows = await q.many()
           return Array.isArray(rows) && rows.length > 0 ? rows[0] : null
         },

--- a/src/adapters/sumak/sumak-adapter.ts
+++ b/src/adapters/sumak/sumak-adapter.ts
@@ -1,0 +1,282 @@
+import type { Sumak } from "sumak"
+import type { Adapter, TablesSchema, Where } from "../../types/index.ts"
+import type { AdapterDebugLogs } from "../create/index.ts"
+import type { SumakDatabaseType } from "./types.ts"
+import { and, or } from "sumak"
+import { createAdapterFactory } from "../create/index.ts"
+import { createSumakMigratorFromSumak } from "./migrator.ts"
+
+export interface SumakAdapterConfig {
+  /**
+   * Database type sumak is configured for.
+   */
+  type?: SumakDatabaseType
+  /**
+   * Enable debug logs for the adapter
+   *
+   * @default false
+   */
+  debugLogs?: AdapterDebugLogs
+  /**
+   * Use plural for table names.
+   *
+   * @default false
+   */
+  usePlural?: boolean
+}
+
+/**
+ * Build a `Col`-style expression for a single Where condition.
+ *
+ * Sumak's `where(({ col1, col2 }) => col1.eq(...))` callback style works at
+ * runtime without static table types — we just dereference the column proxy
+ * by name and call the appropriate operator. We `as any` because the
+ * adapter runs against a runtime `TablesSchema`, not a compile-time DB
+ * schema.
+ */
+function applyOperator(col: any, operator: string, value: unknown): any {
+  const op = operator.toLowerCase()
+  if (op === "in") {
+    return col.in(Array.isArray(value) ? value : [value])
+  }
+  if (op === "contains") return col.like(`%${value}%`)
+  if (op === "starts_with") return col.like(`${value}%`)
+  if (op === "ends_with") return col.like(`%${value}`)
+  if (op === "eq" || op === "=") return col.eq(value)
+  if (op === "ne" || op === "<>" || op === "!=") return col.neq(value)
+  if (op === "gt" || op === ">") return col.gt(value)
+  if (op === "gte" || op === ">=") return col.gte(value)
+  if (op === "lt" || op === "<") return col.lt(value)
+  if (op === "lte" || op === "<=") return col.lte(value)
+  return col.eq(value)
+}
+
+export function sumakAdapter<
+  T extends Record<string, any>,
+  Schema extends TablesSchema = TablesSchema,
+>(
+  db: Sumak<any>,
+  config?: SumakAdapterConfig,
+): (getTables: (options: any) => Schema, options: any) => Adapter<T, Schema> {
+  return createAdapterFactory<T, Schema>({
+    config: {
+      adapterId: "sumak",
+      adapterName: "Sumak Adapter",
+      usePlural: config?.usePlural,
+      debugLogs: config?.debugLogs,
+      // Same defaults as Kysely / Knex: SQLite & MSSQL don't have native
+      // boolean / datetime types we want to round-trip, so the framework
+      // handles 0/1 and ISO strings for us.
+      supportsBooleans: !(config?.type === "sqlite" || config?.type === "mssql" || !config?.type),
+      supportsDates: !(config?.type === "sqlite" || config?.type === "mssql" || !config?.type),
+      supportsJSON: false,
+    },
+    adapter: ({ getFieldName, schema }) => {
+      function transformValueToDB(value: any, model: string, field: string): any {
+        if (field === "id") return value
+        const { type = "sqlite" } = config || {}
+        let f = schema[model]?.fields[field]
+        if (!f) {
+          // @ts-expect-error - model name might be a sanitized custom name
+          f = Object.values(schema).find((f) => f.modelName === model)!
+        }
+        if (
+          f.type === "boolean" &&
+          (type === "sqlite" || type === "mssql") &&
+          value !== null &&
+          value !== undefined
+        ) {
+          return value ? 1 : 0
+        }
+        if (f.type === "date" && value && value instanceof Date) {
+          return type === "sqlite" ? value.toISOString() : value
+        }
+        return value
+      }
+
+      // Build a sumak `WhereCallback` from our `Where[]`. The result is
+      // a single combined expression suitable for `.where(eb => ...)`.
+      function buildWhereExpr(model: string, w: Where[] | undefined): ((eb: any) => any) | null {
+        if (!w || w.length === 0) return null
+        const ands = w.filter((c) => (c.connector ?? "AND") !== "OR")
+        const ors = w.filter((c) => c.connector === "OR")
+        return (eb: any) => {
+          const piece = (c: Where): any => {
+            const fieldName = getFieldName({ model, field: c.field })
+            const col = eb[fieldName]
+            const value = transformValueToDB(c.value, model, c.field)
+            return applyOperator(col, c.operator ?? "=", value)
+          }
+          const parts: any[] = []
+          if (ands.length > 0) {
+            parts.push(ands.length === 1 ? piece(ands[0]) : and(...ands.map(piece)))
+          }
+          if (ors.length > 0) {
+            parts.push(ors.length === 1 ? piece(ors[0]) : or(...ors.map(piece)))
+          }
+          return parts.length === 1 ? parts[0] : and(...parts)
+        }
+      }
+
+      const supportsReturning = config?.type !== "mysql"
+
+      async function fetchByPrimaryKey(
+        model: string,
+        idField: string,
+        idValue: unknown,
+      ): Promise<any> {
+        const row = await (db as any)
+          .selectFrom(model)
+          .selectAll()
+          .where((eb: any) => eb[idField].eq(idValue))
+          .first()
+        return row
+      }
+
+      return {
+        create: async ({ data, model }) => {
+          const idField = getFieldName({ model, field: "id" })
+          if (!supportsReturning) {
+            const result = await (db as any).insertInto(model).values(data).exec()
+            const supplied = (data as { id?: unknown }).id
+            const insertedId =
+              typeof supplied === "string" || typeof supplied === "number"
+                ? supplied
+                : (result?.insertId ?? result?.lastInsertId)
+            if (insertedId !== undefined) {
+              const row = await fetchByPrimaryKey(model, idField, insertedId)
+              if (row) return row
+            }
+            // Last resort fallback — race-prone but mirrors what Kysely
+            // does on MySQL when no insertId is available either.
+            return await (db as any).selectFrom(model).selectAll().orderBy(idField, "DESC").first()
+          }
+          const rows = await (db as any).insertInto(model).values(data).returningAll().many()
+          return Array.isArray(rows) ? rows[0] : rows
+        },
+
+        findOne: async ({ model, where }) => {
+          let query: any = (db as any).selectFrom(model).selectAll()
+          const cb = buildWhereExpr(model, where)
+          if (cb) query = query.where(cb)
+          const res = await query.first()
+          return res ?? null
+        },
+
+        findMany: async ({ model, where, limit, offset, sortBy }) => {
+          let query: any = (db as any).selectFrom(model).selectAll()
+          const cb = buildWhereExpr(model, where)
+          if (cb) query = query.where(cb)
+          if (sortBy) {
+            query = query.orderBy(
+              getFieldName({ model, field: sortBy.field }),
+              sortBy.direction.toUpperCase(),
+            )
+          }
+          // MSSQL requires ORDER BY when OFFSET is used.
+          if (config?.type === "mssql" && offset && !sortBy) {
+            query = query.orderBy(getFieldName({ model, field: "id" }), "ASC")
+          }
+          query = query.limit(limit || 100)
+          if (offset) query = query.offset(offset)
+          return await query.many()
+        },
+
+        update: async ({ model, where, update: values }) => {
+          const cb = buildWhereExpr(model, where)
+          if (!supportsReturning) {
+            let q: any = (db as any).update(model).set(values)
+            if (cb) q = q.where(cb)
+            await q.exec()
+            // Fetch the updated row by the first where clause, mirroring
+            // the Knex/Kysely MySQL adapter strategy.
+            if (where && where.length > 0) {
+              const w = where[0]
+              const fieldName = getFieldName({ model, field: w.field })
+              const value = transformValueToDB(w.value, model, w.field)
+              const row = await (db as any)
+                .selectFrom(model)
+                .selectAll()
+                .where((eb: any) => eb[fieldName].eq(value))
+                .first()
+              return row
+            }
+            return null
+          }
+          let q: any = (db as any).update(model).set(values).returningAll()
+          if (cb) q = q.where(cb)
+          const rows = await q.many()
+          return Array.isArray(rows) && rows.length > 0 ? rows[0] : null
+        },
+
+        updateMany: async ({ model, where, update: values }) => {
+          let q: any = (db as any).update(model).set(values)
+          const cb = buildWhereExpr(model, where)
+          if (cb) q = q.where(cb)
+          const res = await q.exec()
+          return res?.affected ?? 0
+        },
+
+        count: async ({ model, where }) => {
+          let q: any = (db as any).selectCount(model)
+          const cb = buildWhereExpr(model, where)
+          if (cb) q = q.where(cb)
+          const rows = await q.many()
+          const raw = rows?.[0]?.count
+          if (typeof raw === "string") return Number.parseInt(raw, 10)
+          if (typeof raw === "bigint") return Number(raw)
+          if (typeof raw === "number") return raw
+          return Number(raw ?? 0)
+        },
+
+        delete: async ({ model, where }) => {
+          let q: any = (db as any).deleteFrom(model)
+          const cb = buildWhereExpr(model, where)
+          if (cb) {
+            q = q.where(cb)
+          } else {
+            q = q.allRows()
+          }
+          await q.exec()
+        },
+
+        deleteMany: async ({ model, where }) => {
+          let q: any = (db as any).deleteFrom(model)
+          const cb = buildWhereExpr(model, where)
+          if (cb) {
+            q = q.where(cb)
+          } else {
+            q = q.allRows()
+          }
+          const res = await q.exec()
+          return res?.affected ?? 0
+        },
+
+        transaction: async (cb: any) => {
+          // Sumak's `db.transaction` hands the callback a fully-scoped
+          // Sumak instance with the same surface as `db`. We rebuild a
+          // wrapped adapter inside so callers' adapter operations stay
+          // inside the transaction.
+          return await (db as any).transaction(async (tx: any) => {
+            const txAdapter = sumakAdapter<T, Schema>(tx, config)
+            // The `getTables` / options here are ignored — `cb` only
+            // cares about the adapter's runtime methods.
+            return await cb(
+              txAdapter(() => schema as Schema, {
+                database: undefined as any,
+              } as any),
+            )
+          })
+        },
+
+        createMigrator: () =>
+          createSumakMigratorFromSumak({
+            db,
+            dialect: config?.type ?? "sqlite",
+          }),
+
+        options: config,
+      }
+    },
+  })
+}

--- a/src/adapters/sumak/types.ts
+++ b/src/adapters/sumak/types.ts
@@ -1,0 +1,1 @@
+export type SumakDatabaseType = "postgres" | "mysql" | "sqlite" | "mssql"

--- a/tests/sumak/normal/adapter.sumak.test.ts
+++ b/tests/sumak/normal/adapter.sumak.test.ts
@@ -1,0 +1,124 @@
+// @ts-nocheck
+import type { AdapterOptions } from "../../../src/types/index.ts"
+import type { BetterAuthOptions } from "../../better-auth.schema.ts"
+import fsPromises from "node:fs/promises"
+import path from "node:path"
+import Database from "better-sqlite3"
+import merge from "deepmerge"
+import { createPool } from "mysql2/promise"
+import { mysqlDialect, sqliteDialect, sumak } from "sumak"
+import { betterSqlite3Driver } from "sumak/drivers/better-sqlite3"
+import { mysql2Driver } from "sumak/drivers/mysql2"
+import { afterAll, beforeAll, describe } from "vitest"
+import { sumakAdapter } from "../../../src/adapters/sumak/index.ts"
+import { getMigrations } from "../../../src/db/get-migration.ts"
+import { getAuthTables } from "../../better-auth.schema.ts"
+import { runAdapterTest } from "../../test.ts"
+import { isolatedMysqlDb } from "../../utils/mysql.ts"
+
+const sqliteFile = path.join(__dirname, "test.db")
+const mysqlIso = isolatedMysqlDb("sumak_normal")
+
+const sqliteHandle = new Database(sqliteFile)
+const sumakSqlite = sumak({
+  dialect: sqliteDialect(),
+  driver: betterSqlite3Driver(sqliteHandle),
+  tables: {} as any,
+}) as any
+
+let mysqlPool: ReturnType<typeof createPool>
+let sumakMysql: any
+
+export function opts({
+  database,
+  isNumberIdTest,
+}: {
+  database: AdapterOptions["database"]
+  isNumberIdTest: boolean
+}): AdapterOptions<BetterAuthOptions> {
+  return {
+    database,
+    user: {
+      fields: {
+        email: "email_address",
+      },
+      additionalFields: {
+        test: {
+          type: "string",
+          defaultValue: "test",
+        },
+      },
+    },
+    advanced: {
+      database: {
+        useNumberId: isNumberIdTest,
+      },
+    },
+  } as AdapterOptions<BetterAuthOptions>
+}
+
+describe("sumak adapter test", async () => {
+  beforeAll(async () => {
+    console.log(`Now running normal Sumak adapter test...`)
+    await mysqlIso.setup()
+    mysqlPool = createPool(mysqlIso.url)
+    sumakMysql = sumak({
+      dialect: mysqlDialect(),
+      driver: mysql2Driver(mysqlPool),
+      tables: {} as any,
+    }) as any
+
+    const sqliteFactory = sumakAdapter(sumakSqlite, { type: "sqlite" })
+    const mysqlFactory = sumakAdapter(sumakMysql, { type: "mysql" })
+
+    const sqliteOptions = opts({
+      database: sqliteFactory as any,
+      isNumberIdTest: false,
+    })
+    const mysqlOptions = opts({
+      database: mysqlFactory as any,
+      isNumberIdTest: false,
+    })
+
+    await (await getMigrations(sqliteOptions, getAuthTables)).runMigrations()
+    await (await getMigrations(mysqlOptions, getAuthTables)).runMigrations()
+  })
+
+  afterAll(async () => {
+    sqliteHandle.close()
+    if (mysqlPool) await mysqlPool.end()
+    await mysqlIso.teardown()
+    await fsPromises.unlink(sqliteFile)
+  })
+
+  const mysqlOptions = opts({
+    database: { db: null as any, type: "mysql" },
+    isNumberIdTest: false,
+  })
+  const sqliteOptions = opts({
+    database: { db: null as any, type: "sqlite" },
+    isNumberIdTest: false,
+  })
+
+  await runAdapterTest({
+    getAdapter: async (customOptions = {}) => {
+      const factory = sumakAdapter(sumakMysql, {
+        type: "mysql",
+        debugLogs: { isRunningAdapterTests: true },
+      })
+      return factory(getAuthTables, merge(customOptions, mysqlOptions))
+    },
+    testPrefix: "sumak-mysql",
+  })
+
+  await runAdapterTest({
+    getAdapter: async (customOptions = {}) => {
+      const factory = sumakAdapter(sumakSqlite, {
+        type: "sqlite",
+        debugLogs: { isRunningAdapterTests: true },
+      })
+      return factory(getAuthTables, merge(customOptions, sqliteOptions))
+    },
+    testPrefix: "sumak-sqlite",
+  })
+})

--- a/tests/sumak/number-id/adapter.sumak.number-id.test.ts
+++ b/tests/sumak/number-id/adapter.sumak.number-id.test.ts
@@ -1,0 +1,124 @@
+// @ts-nocheck
+import type { AdapterOptions } from "../../../src/types/index.ts"
+import type { BetterAuthOptions } from "../../better-auth.schema.ts"
+import fsPromises from "node:fs/promises"
+import path from "node:path"
+import Database from "better-sqlite3"
+import merge from "deepmerge"
+import { createPool } from "mysql2/promise"
+import { mysqlDialect, sqliteDialect, sumak } from "sumak"
+import { betterSqlite3Driver } from "sumak/drivers/better-sqlite3"
+import { mysql2Driver } from "sumak/drivers/mysql2"
+import { afterAll, beforeAll, describe } from "vitest"
+import { sumakAdapter } from "../../../src/adapters/sumak/index.ts"
+import { getMigrations } from "../../../src/db/get-migration.ts"
+import { getAuthTables } from "../../better-auth.schema.ts"
+import { runNumberIdAdapterTest } from "../../test.ts"
+import { isolatedMysqlDb } from "../../utils/mysql.ts"
+
+const sqliteFile = path.join(__dirname, "test.db")
+const mysqlIso = isolatedMysqlDb("sumak_numid")
+
+const sqliteHandle = new Database(sqliteFile)
+const sumakSqlite = sumak({
+  dialect: sqliteDialect(),
+  driver: betterSqlite3Driver(sqliteHandle),
+  tables: {} as any,
+}) as any
+
+let mysqlPool: ReturnType<typeof createPool>
+let sumakMysql: any
+
+export function opts({
+  database,
+  isNumberIdTest,
+}: {
+  database: AdapterOptions["database"]
+  isNumberIdTest: boolean
+}): AdapterOptions<BetterAuthOptions> {
+  return {
+    database,
+    user: {
+      fields: {
+        email: "email_address",
+      },
+      additionalFields: {
+        test: {
+          type: "string",
+          defaultValue: "test",
+        },
+      },
+    },
+    advanced: {
+      database: {
+        useNumberId: isNumberIdTest,
+      },
+    },
+  } as AdapterOptions<BetterAuthOptions>
+}
+
+describe("sumak number id adapter tests", async () => {
+  beforeAll(async () => {
+    console.log(`Now running Number ID Sumak adapter test...`)
+    await mysqlIso.setup()
+    mysqlPool = createPool(mysqlIso.url)
+    sumakMysql = sumak({
+      dialect: mysqlDialect(),
+      driver: mysql2Driver(mysqlPool),
+      tables: {} as any,
+    }) as any
+
+    const sqliteFactory = sumakAdapter(sumakSqlite, { type: "sqlite" })
+    const mysqlFactory = sumakAdapter(sumakMysql, { type: "mysql" })
+
+    const sqliteOptions = opts({
+      database: sqliteFactory as any,
+      isNumberIdTest: true,
+    })
+    const mysqlOptions = opts({
+      database: mysqlFactory as any,
+      isNumberIdTest: true,
+    })
+
+    await (await getMigrations(sqliteOptions, getAuthTables)).runMigrations()
+    await (await getMigrations(mysqlOptions, getAuthTables)).runMigrations()
+  })
+
+  afterAll(async () => {
+    sqliteHandle.close()
+    if (mysqlPool) await mysqlPool.end()
+    await mysqlIso.teardown()
+    await fsPromises.unlink(sqliteFile)
+  })
+
+  const mysqlOptions = opts({
+    database: { db: null as any, type: "mysql" },
+    isNumberIdTest: true,
+  })
+  const sqliteOptions = opts({
+    database: { db: null as any, type: "sqlite" },
+    isNumberIdTest: true,
+  })
+
+  await runNumberIdAdapterTest({
+    getAdapter: async (customOptions = {}) => {
+      const factory = sumakAdapter(sumakMysql, {
+        type: "mysql",
+        debugLogs: { isRunningAdapterTests: false },
+      })
+      return factory(getAuthTables, merge(customOptions, mysqlOptions))
+    },
+    testPrefix: "sumak-mysql",
+  })
+
+  await runNumberIdAdapterTest({
+    getAdapter: async (customOptions = {}) => {
+      const factory = sumakAdapter(sumakSqlite, {
+        type: "sqlite",
+        debugLogs: { isRunningAdapterTests: false },
+      })
+      return factory(getAuthTables, merge(customOptions, sqliteOptions))
+    },
+    testPrefix: "sumak-sqlite",
+  })
+})


### PR DESCRIPTION
Adds a unadapter adapter for [Sumak](https://github.com/productdevbook/sumak), the type-safe, AST-first, zero-dependency SQL query builder.

## What's included

- **CRUD via sumak's typed builder**: `selectFrom`, `insertInto`, `update`, `deleteFrom`, `selectCount`. WHERE callbacks routed through sumak's `Col`-style operators (`eq` / `neq` / `gt` / `gte` / `lt` / `lte` / `in` / `like`); AND/OR composed via sumak's `and()` / `or()`.
- **INSERT / UPDATE returning**: `.returningAll()` on Postgres / SQLite / MSSQL. MySQL has no RETURNING, so we use `insertId` from the mysql2 driver result + a follow-up primary-key SELECT (same strategy the Knex adapter uses).
- **Transactions**: optional `transaction` is wired through `db.transaction(tx => ...)` — the wrapped tx adapter has the same surface as the outer adapter.
- **Migrator**: ships its own `AdapterMigrator` — introspect via sumak's `introspect(driver, dialect)`, DDL via `db.schema.createTable / alterTable / createIndex` → `compileDDL` → `executeCompiledNoRows`. JSON columns, index DDL, uuid / serial id strategies, server-side `CURRENT_TIMESTAMP` defaults all flow through.
- **Tests**: `tests/sumak/{normal,number-id}/` reuse the `isolatedMysqlDb` helper from the Knex test infra. Each suite drops + recreates its own DB so it stays independent from the kysely / knex / drizzle / prisma suites.
- **README**: new row in the Available Adapters table, new row in the Migrations matrix, full "Sumak Adapter Example" section.

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean (only pre-existing warnings unrelated to sumak)
- [x] `pnpm build` emits `dist/adapters/sumak/{index,sumak-adapter,migrator,types}.mjs`
- [x] Memory + create + migration unit tests (90+) green locally
- [ ] Full CI (kysely / knex / drizzle / prisma / mongodb / **sumak**) — pending green

## Notes
- Sumak is generics-driven; the adapter casts to `Sumak<any>` because schemas come from unadapter's runtime `TablesSchema`, not statically.
- `transaction` callback wraps `tx` with a fresh adapter so caller operations stay in the transaction; same shape as the outer adapter so consumers can use it interchangeably.
- Sumak v0.0.x is pre-1.0 so this adapter is pinned to `^0.0.14` in devDependencies.

🤖 Generated with [Claude Code](https://claude.com/claude-code)