### PR TITLE
fix: stop silently dropping dist files; document Where[] AND/OR

### DIFF
--- a/package.json
+++ b/package.json
@@ -83,7 +83,7 @@
     }
   },
   "scripts": {
-    "build": "obuild",
+    "build": "obuild && node scripts/verify-build.mjs",
     "dev": "vitest",
     "lint": "oxlint . && oxfmt --check .",
     "lint:fix": "oxlint . --fix && oxfmt .",

--- a/scripts/verify-build.mjs
+++ b/scripts/verify-build.mjs
@@ -47,9 +47,7 @@ for (const file of walk(ROOT)) {
 }
 
 if (missing.length > 0) {
-  console.error(
-    `\n[verify-build] Found ${missing.length} broken relative import(s) in dist/:\n`,
-  )
+  console.error(`\n[verify-build] Found ${missing.length} broken relative import(s) in dist/:\n`)
   for (const { file, spec, target } of missing) {
     console.error(`  ${file.replace(ROOT, "dist")}`)
     console.error(`    → "${spec}" (resolved: ${target.replace(ROOT, "dist")})`)

--- a/scripts/verify-build.mjs
+++ b/scripts/verify-build.mjs
@@ -1,0 +1,63 @@
+#!/usr/bin/env node
+/**
+ * Walk every emitted `.mjs` / `.d.mts` file and verify each `from "./..."`
+ * specifier resolves to a real file. obuild's transform mode silently
+ * skips emitting files when isolatedDeclarations can't infer a return
+ * type, leaving barrels that re-export ghosts. CI never noticed because
+ * the bundler stays quiet — but the published package fails at import
+ * time.
+ *
+ * Run via `pnpm build:verify` (chained after `pnpm build` in CI).
+ */
+import { readdirSync, readFileSync, statSync } from "node:fs"
+import { dirname, extname, join, resolve } from "node:path"
+import process from "node:process"
+
+const ROOT = resolve(process.cwd(), "dist")
+
+function* walk(dir) {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry)
+    if (statSync(full).isDirectory()) {
+      yield* walk(full)
+    } else if (entry.endsWith(".mjs") || entry.endsWith(".d.mts")) {
+      yield full
+    }
+  }
+}
+
+const IMPORT_RE = /from\s+["']([^"']+)["']/g
+
+const missing = []
+
+for (const file of walk(ROOT)) {
+  const src = readFileSync(file, "utf-8")
+  for (const match of src.matchAll(IMPORT_RE)) {
+    const spec = match[1]
+    if (!spec.startsWith(".")) continue
+    const ext = extname(spec)
+    if (ext !== ".mjs" && ext !== ".mts") continue
+    const target = resolve(dirname(file), spec)
+    try {
+      statSync(target)
+    } catch {
+      missing.push({ file, spec, target })
+    }
+  }
+}
+
+if (missing.length > 0) {
+  console.error(
+    `\n[verify-build] Found ${missing.length} broken relative import(s) in dist/:\n`,
+  )
+  for (const { file, spec, target } of missing) {
+    console.error(`  ${file.replace(ROOT, "dist")}`)
+    console.error(`    → "${spec}" (resolved: ${target.replace(ROOT, "dist")})`)
+  }
+  console.error(
+    `\nLikely cause: obuild silently skipped emit for those files. Add an explicit return type to the offending exported function.\n`,
+  )
+  process.exit(1)
+}
+
+console.log(`[verify-build] OK — every relative import in dist/ resolves.`)

--- a/src/adapters/create/index.ts
+++ b/src/adapters/create/index.ts
@@ -67,7 +67,10 @@ export function createAdapterFactory<
 }: {
   config: AdapterConfig<T, Schema>
   adapter: CreateCustomAdapter<Schema>
-}) {
+}): (
+  getTables: (options: AdapterOptions<T, Schema>) => Schema,
+  options: AdapterOptions<T, Schema>,
+) => Adapter<T, Schema> {
   return (
     getTables: (options: AdapterOptions<T, Schema>) => Schema,
     options: AdapterOptions<T, Schema>,
@@ -877,4 +880,4 @@ function formatAction(action: string) {
  * backwards compatibility — adapter packages should migrate at their
  * convenience.
  */
-export const createAdapter = createAdapterFactory
+export const createAdapter: typeof createAdapterFactory = createAdapterFactory

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,9 +1,13 @@
 import type { FieldAttribute, TablesSchema } from "../types/index.ts"
 import type { Account, User } from "../types/index.ts"
 import type { AdapterOptions } from "../types/options.ts"
+import type { ZodTypeAny } from "zod"
 import { z } from "zod"
 
-export const accountSchema = z.object({
+// These are runtime validators; the matching TypeScript types live in
+// `src/types/models.ts` written explicitly so `--isolatedDeclarations`
+// can emit our public `.d.mts` without following zod's inference chain.
+export const accountSchema: ZodTypeAny = z.object({
   id: z.string(),
   providerId: z.string(),
   accountId: z.string(),
@@ -11,29 +15,17 @@ export const accountSchema = z.object({
   accessToken: z.string().nullish(),
   refreshToken: z.string().nullish(),
   idToken: z.string().nullish(),
-  /**
-   * Access token expires at
-   */
   accessTokenExpiresAt: z.date().nullish(),
-  /**
-   * Refresh token expires at
-   */
   refreshTokenExpiresAt: z.date().nullish(),
-  /**
-   * The scopes that the user has authorized
-   */
   scope: z.string().nullish(),
-  /**
-   * Password is only stored in the credential provider
-   */
   password: z.string().nullish(),
   createdAt: z.date().default(() => new Date()),
   updatedAt: z.date().default(() => new Date()),
 })
 
-export const userSchema = z.object({
+export const userSchema: ZodTypeAny = z.object({
   id: z.string(),
-  email: z.string().transform((val) => val.toLowerCase()),
+  email: z.string().transform((val: string) => val.toLowerCase()),
   emailVerified: z.boolean().default(false),
   name: z.string(),
   image: z.string().nullish(),
@@ -41,7 +33,7 @@ export const userSchema = z.object({
   updatedAt: z.date().default(() => new Date()),
 })
 
-export const verificationSchema = z.object({
+export const verificationSchema: ZodTypeAny = z.object({
   id: z.string(),
   value: z.string(),
   createdAt: z.date().default(() => new Date()),

--- a/src/types/adapter.ts
+++ b/src/types/adapter.ts
@@ -4,7 +4,24 @@ import type { AdapterOptions } from "./options.ts"
 import type { TablesSchema } from "./schema.ts"
 
 /**
- * Adapter where clause
+ * Adapter where clause.
+ *
+ * `connector` declares which bucket the condition belongs to, not how it
+ * pairs with the previous condition. All conditions with `connector: "AND"`
+ * (the default) are AND-ed together; all conditions with `connector: "OR"`
+ * are OR-ed together; the two groups are then AND-ed.
+ *
+ * For input like:
+ * ```
+ *   [{ field: "a" }, { field: "b", connector: "OR" }, { field: "c", connector: "OR" }]
+ * ```
+ * the engine produces `a AND (b OR c)`. For
+ * ```
+ *   [{ field: "a" }, { field: "b", connector: "OR" }, { field: "c" }]
+ * ```
+ * the result is `(a AND c) AND (b)` — note `b` ends up alone in the OR
+ * bucket. If you need a different mix, build it as two consecutive calls
+ * or use the adapter's native query builder.
  */
 export interface Where {
   operator?:
@@ -20,7 +37,7 @@ export interface Where {
     | "ends_with" // eq by default
   value: string | number | boolean | string[] | number[] | Date | null
   field: string
-  connector?: "AND" | "OR" // AND by default
+  connector?: "AND" | "OR" // AND by default — see interface doc
 }
 
 /**

--- a/src/types/models.ts
+++ b/src/types/models.ts
@@ -1,6 +1,3 @@
-import type { z } from "zod"
-import type { accountSchema, userSchema, verificationSchema } from "../db/schema.ts"
-
 export type Models =
   | "user"
   | "account"
@@ -27,7 +24,43 @@ interface RateLimit {
   lastRequest: number
 }
 
-export type User = z.infer<typeof userSchema>
-export type Account = z.infer<typeof accountSchema>
-export type Verification = z.infer<typeof verificationSchema>
+// Surface types written explicitly so they don't depend on zod inference
+// in our public d.ts (`--isolatedDeclarations` can't follow z.infer through
+// the build). The matching Zod schemas are still exported from
+// `unadapter/db` for runtime validation.
+export interface User {
+  id: string
+  email: string
+  emailVerified: boolean
+  name: string
+  image?: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface Account {
+  id: string
+  providerId: string
+  accountId: string
+  userId: string
+  accessToken?: string | null
+  refreshToken?: string | null
+  idToken?: string | null
+  accessTokenExpiresAt?: Date | null
+  refreshTokenExpiresAt?: Date | null
+  scope?: string | null
+  password?: string | null
+  createdAt: Date
+  updatedAt: Date
+}
+
+export interface Verification {
+  id: string
+  value: string
+  createdAt: Date
+  updatedAt: Date
+  expiresAt: Date
+  identifier: string
+}
+
 export type { RateLimit }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -95,4 +95,4 @@ export function createLogger(
   ) as Record<LogLevel, (...params: LogHandlerParams) => void>
 }
 
-export const logger = createLogger()
+export const logger: Record<LogLevel, (...params: LogHandlerParams) => void> = createLogger()

--- a/src/utils/plugin.ts
+++ b/src/utils/plugin.ts
@@ -1,9 +1,23 @@
 import type { AdapterOptions, FieldAttribute } from "../types/index.ts"
 
+export interface MergedPluginSchema {
+  [tableName: string]: {
+    fields: Record<string, FieldAttribute>
+    modelName: string
+  }
+}
+
+/**
+ * Returns `MergedPluginSchema | undefined` at runtime; declared as `any`
+ * so callers can spread `result?.user?.fields` into a stricter
+ * `TablesSchema` shape without TypeScript narrowing the spread to
+ * `string | FieldAttribute` (which conflicts with consumer-supplied
+ * config fields like `options?.user?.fields?.name: string | undefined`).
+ */
 export function mergePluginSchemas<
   T extends Record<string, any>,
   K extends keyof AdapterOptions<T> = "plugins",
->(options: AdapterOptions<T>, where: K = "plugins" as K) {
+>(options: AdapterOptions<T>, where: K = "plugins" as K): any {
   const schema = (options[where] as any[])?.reduce(
     (acc, plugin) => {
       const schema = plugin.schema
@@ -24,7 +38,7 @@ export function mergePluginSchemas<
       }
       return acc
     },
-    {} as Record<string, { fields: Record<string, FieldAttribute>; modelName: string }>,
+    {} as MergedPluginSchema,
   )
 
   return schema

--- a/src/utils/plugin.ts
+++ b/src/utils/plugin.ts
@@ -18,28 +18,25 @@ export function mergePluginSchemas<
   T extends Record<string, any>,
   K extends keyof AdapterOptions<T> = "plugins",
 >(options: AdapterOptions<T>, where: K = "plugins" as K): any {
-  const schema = (options[where] as any[])?.reduce(
-    (acc, plugin) => {
-      const schema = plugin.schema
-      if (!schema) return acc
-      for (const [key, value] of Object.entries(schema)) {
-        acc[key] = {
-          fields: {
-            ...acc[key]?.fields,
-            ...(typeof value === "object" && value !== null && "fields" in value
-              ? (value.fields as unknown as Record<string, FieldAttribute>)
-              : {}),
-          },
-          modelName:
-            (typeof value === "object" && value !== null && "modelName" in value
-              ? String(value.modelName)
-              : key) || key,
-        }
+  const schema = (options[where] as any[])?.reduce((acc, plugin) => {
+    const schema = plugin.schema
+    if (!schema) return acc
+    for (const [key, value] of Object.entries(schema)) {
+      acc[key] = {
+        fields: {
+          ...acc[key]?.fields,
+          ...(typeof value === "object" && value !== null && "fields" in value
+            ? (value.fields as unknown as Record<string, FieldAttribute>)
+            : {}),
+        },
+        modelName:
+          (typeof value === "object" && value !== null && "modelName" in value
+            ? String(value.modelName)
+            : key) || key,
       }
-      return acc
-    },
-    {} as MergedPluginSchema,
-  )
+    }
+    return acc
+  }, {} as MergedPluginSchema)
 
   return schema
 }


### PR DESCRIPTION
This PR addresses silent failures that have been masking real bugs across recent merges. CI was happy because everything that compiled, compiled — the failures were warnings on stderr that obuild swallowed. Three categories of silent failure:

## 1. obuild silently dropping files

`obuild` runs in transform mode with `isolatedDeclarations`. Whenever it can't emit a type (zod chains, missing return types, untyped const aliases), it logs a warning **and skips the file**. The barrel `index.mjs` still references the missing file via `export *`, so consumers get `Cannot find module` at runtime. Files we lost across PRs #9 / #10 / #11:

| File | Reason |
|---|---|
| `src/db/schema.ts` | `accountSchema = z.object(...)` — zod object literal, type can't be inferred |
| `src/utils/logger.ts` | `logger = createLogger()` const alias without annotation |
| `src/utils/plugin.ts` | `mergePluginSchemas` had no return type |
| `src/adapters/create/index.ts` | `createAdapterFactory` returned an arrow without an annotation; `createAdapter = createAdapterFactory` alias inherited that |

Fixed by adding explicit annotations everywhere obuild was unhappy. `dist` size 121 KB → 154 KB (33 KB / 24 imports were silently broken).

To stop this from happening again, added `scripts/verify-build.mjs`: walks every `.mjs` / `.d.mts` in `dist/`, follows every relative `from "./..."` import, fails the build if any target doesn't exist on disk. Wired into `pnpm build` so CI catches this immediately. Local run on broken state:

```
[verify-build] Found 24 broken relative import(s) in dist/:
  dist/utils/index.mjs → "./logger.mjs"
  dist/db/index.mjs → "./schema.mjs"
  dist/adapters/index.mjs → "./create/index.mjs"
  ...
```

## 2. `User` / `Account` / `Verification` types went through zod inference

`src/types/models.ts` was doing `export type User = z.infer<typeof userSchema>`. With `isolatedDeclarations` in obuild, the zod inference can't survive into the emitted `.d.mts`, which is partly why `db/schema.ts` was getting dropped. Replaced with hand-written interfaces matching what the schemas validate. The schemas themselves still ship for runtime validation.

## 3. Documented `Where[]` AND/OR semantics

The Knex / Kysely / Sumak adapters all bucket `Where[]` by `connector` field — every `connector: "AND"` (default) goes into one group, every `connector: "OR"` into another, then the two groups are AND-ed. This is shared semantics across the three adapters, but undocumented, which made it read as a bug to reviewers. Added an explicit comment on the `Where` interface so the contract is clear:

```typescript
[{ field: "a" }, { field: "b", connector: "OR" }, { field: "c", connector: "OR" }]
// → a AND (b OR c)
```

## Test plan
- [x] `pnpm typecheck` clean
- [x] `pnpm lint` clean
- [x] `pnpm build` emits all referenced files; `verify-build.mjs` passes
- [x] Memory + create-adapter + migration tests (90+) green locally
- [ ] Full CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)