### PR TITLE
feat: add unadapter/generate API for SQL schema generation

### DIFF
--- a/package.json
+++ b/package.json
@@ -89,6 +89,10 @@
     "./utils": {
       "types": "./dist/utils/index.d.mts",
       "import": "./dist/utils/index.mjs"
+    },
+    "./generate": {
+      "types": "./dist/generate/index.d.mts",
+      "import": "./dist/generate/index.mjs"
     }
   },
   "scripts": {

--- a/src/db/get-migration.ts
+++ b/src/db/get-migration.ts
@@ -69,6 +69,15 @@ function buildIdColumnDef(options: MigratorOptions, migrator: AdapterMigrator): 
   }
 }
 
+export interface GetMigrationsConfig {
+  /**
+   * Skip live introspection and treat the database as empty, so every
+   * table/field is emitted as a fresh CREATE. Used by `unadapter/generate`
+   * to compile a full schema offline (no DB connection / driver).
+   */
+  skipIntrospect?: boolean
+}
+
 /**
  * Adapter-agnostic migration engine. The adapter supplies introspection
  * and DDL via {@link AdapterMigrator}; this engine only does diffing,
@@ -83,6 +92,7 @@ function buildIdColumnDef(options: MigratorOptions, migrator: AdapterMigrator): 
 export async function getMigrations<T extends Record<string, any>>(
   config: AdapterOptions<T>,
   getTables: (options: AdapterOptions<T>) => TablesSchema,
+  migrationsConfig: GetMigrationsConfig = {},
 ): Promise<GetMigrationsResult> {
   const schema = getSchema(config, getTables)
   const logger = createLogger(config.logger)
@@ -92,7 +102,7 @@ export async function getMigrations<T extends Record<string, any>>(
 
   const migrator = await resolveMigrator(config, getTables, logger)
 
-  const tableMetadata = await migrator.introspect()
+  const tableMetadata = migrationsConfig.skipIntrospect ? [] : await migrator.introspect()
 
   const toBeCreated: GetMigrationsResult["toBeCreated"] = []
   const toBeAdded: GetMigrationsResult["toBeAdded"] = []

--- a/src/generate/index.ts
+++ b/src/generate/index.ts
@@ -1,49 +1,37 @@
-import type { Dialect } from "kysely"
 import type { AdapterOptions, TablesSchema } from "../types/index.ts"
 import { getMigrations } from "../db/get-migration.ts"
 
-export type SQLDialect = "postgresql" | "mysql" | "sqlite"
-
 export interface GenerateOptions {
   format?: "sql"
-  dialect?: SQLDialect
 }
 
 /**
- * Build a driverless Kysely dialect for the target SQL flavour. The pool /
- * database handles are intentionally empty — `compileMigrations()` only
- * compiles SQL strings and never reaches the driver (same trick the
- * migration tests use), so generation needs no live connection.
- */
-async function stubDialect(dialect: SQLDialect): Promise<Dialect> {
-  const { PostgresDialect, MysqlDialect, SqliteDialect } = await import("kysely")
-  switch (dialect) {
-    case "mysql":
-      return new MysqlDialect({ pool: {} as any })
-    case "sqlite":
-      return new SqliteDialect({ database: {} as any })
-    default:
-      return new PostgresDialect({ pool: {} as any })
-  }
-}
-
-/**
- * Generate a database schema as a string, without a live database
- * connection. Intended for library authors exposing a `generate` command
- * in their own CLI.
+ * Compile the schema to a SQL DDL string without connecting to a database.
  *
- * Reuses the same migration compile path as `getMigrations().compileMigrations()`
- * (id strategy is resolved from `options.advanced.database`), so generated
- * output matches what `runMigrations()` would actually create.
+ * `options.database` must be an adapter instance (e.g. `kyselyAdapter(db)`,
+ * `knexAdapter(db)`); the dialect is taken from it. The id strategy is read
+ * from `options.advanced.database`.
+ *
+ * @example
+ * const sql = await generate(getTables, {
+ *   database: kyselyAdapter(db, { type: "postgres" }),
+ * })
+ *
+ * @throws if `options.database` is not an adapter instance.
  */
 export async function generate<T extends Record<string, any>>(
   getTables: (options: AdapterOptions<T>) => TablesSchema,
   options: AdapterOptions<T>,
-  generateOptions: GenerateOptions = {},
+  _generateOptions: GenerateOptions = {},
 ): Promise<string> {
-  const { dialect = "postgresql" } = generateOptions
-  const database = (await stubDialect(dialect)) as AdapterOptions<T>["database"]
-  const { compileMigrations } = await getMigrations({ ...options, database }, getTables, {
+  if (typeof options.database !== "function") {
+    throw new Error(
+      "[unadapter] generate() requires an adapter instance as options.database " +
+        "(e.g. kyselyAdapter(db), knexAdapter(db)). The adapter supplies the target " +
+        "dialect and offline SQL compilation via its createMigrator().",
+    )
+  }
+  const { compileMigrations } = await getMigrations(options, getTables, {
     skipIntrospect: true,
   })
   return compileMigrations()

--- a/src/generate/index.ts
+++ b/src/generate/index.ts
@@ -1,0 +1,50 @@
+import type { Dialect } from "kysely"
+import type { AdapterOptions, TablesSchema } from "../types/index.ts"
+import { getMigrations } from "../db/get-migration.ts"
+
+export type SQLDialect = "postgresql" | "mysql" | "sqlite"
+
+export interface GenerateOptions {
+  format?: "sql"
+  dialect?: SQLDialect
+}
+
+/**
+ * Build a driverless Kysely dialect for the target SQL flavour. The pool /
+ * database handles are intentionally empty — `compileMigrations()` only
+ * compiles SQL strings and never reaches the driver (same trick the
+ * migration tests use), so generation needs no live connection.
+ */
+async function stubDialect(dialect: SQLDialect): Promise<Dialect> {
+  const { PostgresDialect, MysqlDialect, SqliteDialect } = await import("kysely")
+  switch (dialect) {
+    case "mysql":
+      return new MysqlDialect({ pool: {} as any })
+    case "sqlite":
+      return new SqliteDialect({ database: {} as any })
+    default:
+      return new PostgresDialect({ pool: {} as any })
+  }
+}
+
+/**
+ * Generate a database schema as a string, without a live database
+ * connection. Intended for library authors exposing a `generate` command
+ * in their own CLI.
+ *
+ * Reuses the same migration compile path as `getMigrations().compileMigrations()`
+ * (id strategy is resolved from `options.advanced.database`), so generated
+ * output matches what `runMigrations()` would actually create.
+ */
+export async function generate<T extends Record<string, any>>(
+  getTables: (options: AdapterOptions<T>) => TablesSchema,
+  options: AdapterOptions<T>,
+  generateOptions: GenerateOptions = {},
+): Promise<string> {
+  const { dialect = "postgresql" } = generateOptions
+  const database = (await stubDialect(dialect)) as AdapterOptions<T>["database"]
+  const { compileMigrations } = await getMigrations({ ...options, database }, getTables, {
+    skipIntrospect: true,
+  })
+  return compileMigrations()
+}

--- a/tests/generate/generate.test.ts
+++ b/tests/generate/generate.test.ts
@@ -1,0 +1,83 @@
+// @ts-nocheck
+import type { AdapterOptions, TablesSchema } from "../../src/types/index.ts"
+import { describe, expect, test } from "vitest"
+import { generate } from "../../src/generate/index.ts"
+
+const tables: TablesSchema = {
+  user: {
+    modelName: "user",
+    fields: {
+      email: { type: "string", required: true, unique: true, index: true },
+      bio: { type: "string", required: false },
+      createdAt: { type: "date", defaultValue: () => new Date() },
+    },
+  },
+  post: {
+    modelName: "post",
+    fields: {
+      title: { type: "string", required: true },
+      authorId: {
+        type: "string",
+        required: true,
+        references: { model: "user", field: "id" },
+      },
+      meta: { type: "json", required: false },
+    },
+    order: 2,
+  },
+}
+
+const getTables = () => tables
+
+function opts(advancedDb: Record<string, unknown> = {}): AdapterOptions {
+  return { advanced: { database: advancedDb } } as AdapterOptions
+}
+
+describe("generate() — offline SQL schema", () => {
+  test("postgresql: text PK, jsonb, timestamp default, FK, index", async () => {
+    const sql = await generate(getTables, opts(), { format: "sql", dialect: "postgresql" })
+    expect(sql).toMatch(/create table "user"/i)
+    expect(sql).toContain('"id" text not null primary key')
+    expect(sql).toContain('"createdAt" timestamp')
+    expect(sql).toContain("default CURRENT_TIMESTAMP")
+    expect(sql).toContain('"meta" jsonb')
+    expect(sql).toMatch(/references "user" ?\("id"\)/)
+    expect(sql).toMatch(/create unique index "user_email_idx"/i)
+  })
+
+  test("mysql: varchar(36) FK + json type + backtick quoting", async () => {
+    const sql = await generate(getTables, opts(), { dialect: "mysql" })
+    expect(sql).toContain("varchar(36)")
+    expect(sql).toContain("`meta` json")
+  })
+
+  test("sqlite: TEXT for json", async () => {
+    const sql = await generate(getTables, opts(), { dialect: "sqlite" })
+    expect(sql).toContain('"meta" text')
+  })
+
+  test("defaults to postgresql when no dialect given", async () => {
+    const sql = await generate(getTables, opts())
+    expect(sql).toMatch(/create table "user"/i)
+    expect(sql).toContain('"id" text not null primary key')
+  })
+
+  test("useNumberId: integer PK", async () => {
+    const sql = await generate(getTables, opts({ useNumberId: true }), { dialect: "sqlite" })
+    expect(sql).toContain('"id" integer')
+  })
+
+  test("uuid id strategy: postgres gen_random_uuid() default", async () => {
+    const sql = await generate(getTables, opts({ generateId: "uuid" }), { dialect: "postgresql" })
+    expect(sql).toContain("gen_random_uuid()")
+  })
+
+  test("orders tables by `order` — post (order:2) before user (unordered)", async () => {
+    const sql = await generate(getTables, opts(), { dialect: "postgresql" })
+    const userIdx = sql.search(/create table "user"/i)
+    const postIdx = sql.search(/create table "post"/i)
+    expect(userIdx).toBeGreaterThanOrEqual(0)
+    expect(postIdx).toBeGreaterThanOrEqual(0)
+    expect(postIdx).toBeLessThan(userIdx)
+  })
+})

--- a/tests/generate/generate.test.ts
+++ b/tests/generate/generate.test.ts
@@ -1,6 +1,8 @@
 // @ts-nocheck
 import type { AdapterOptions, TablesSchema } from "../../src/types/index.ts"
+import { Kysely, MysqlDialect, PostgresDialect, SqliteDialect } from "kysely"
 import { describe, expect, test } from "vitest"
+import { kyselyAdapter } from "../../src/adapters/kysely/kysely-adapter.ts"
 import { generate } from "../../src/generate/index.ts"
 
 const tables: TablesSchema = {
@@ -29,13 +31,29 @@ const tables: TablesSchema = {
 
 const getTables = () => tables
 
-function opts(advancedDb: Record<string, unknown> = {}): AdapterOptions {
-  return { advanced: { database: advancedDb } } as AdapterOptions
+// Build a driverless Kysely instance wrapped in an adapter — we never
+// .execute(), only .compile().sql, so no live connection is needed.
+function adapterFor(type: "postgres" | "mysql" | "sqlite") {
+  const dialect =
+    type === "postgres"
+      ? new PostgresDialect({ pool: {} as any })
+      : type === "mysql"
+        ? new MysqlDialect({ pool: {} as any })
+        : new SqliteDialect({ database: {} as any })
+  const db = new Kysely<any>({ dialect })
+  return kyselyAdapter(db, { type })
+}
+
+function opts(
+  type: "postgres" | "mysql" | "sqlite",
+  advancedDb: Record<string, unknown> = {},
+): AdapterOptions {
+  return { database: adapterFor(type), advanced: { database: advancedDb } } as AdapterOptions
 }
 
 describe("generate() — offline SQL schema", () => {
-  test("postgresql: text PK, jsonb, timestamp default, FK, index", async () => {
-    const sql = await generate(getTables, opts(), { format: "sql", dialect: "postgresql" })
+  test("postgres: text PK, jsonb, timestamp default, FK, index", async () => {
+    const sql = await generate(getTables, opts("postgres"), { format: "sql" })
     expect(sql).toMatch(/create table "user"/i)
     expect(sql).toContain('"id" text not null primary key')
     expect(sql).toContain('"createdAt" timestamp')
@@ -46,38 +64,38 @@ describe("generate() — offline SQL schema", () => {
   })
 
   test("mysql: varchar(36) FK + json type + backtick quoting", async () => {
-    const sql = await generate(getTables, opts(), { dialect: "mysql" })
+    const sql = await generate(getTables, opts("mysql"))
     expect(sql).toContain("varchar(36)")
     expect(sql).toContain("`meta` json")
   })
 
   test("sqlite: TEXT for json", async () => {
-    const sql = await generate(getTables, opts(), { dialect: "sqlite" })
+    const sql = await generate(getTables, opts("sqlite"))
     expect(sql).toContain('"meta" text')
   })
 
-  test("defaults to postgresql when no dialect given", async () => {
-    const sql = await generate(getTables, opts())
-    expect(sql).toMatch(/create table "user"/i)
-    expect(sql).toContain('"id" text not null primary key')
-  })
-
   test("useNumberId: integer PK", async () => {
-    const sql = await generate(getTables, opts({ useNumberId: true }), { dialect: "sqlite" })
+    const sql = await generate(getTables, opts("sqlite", { useNumberId: true }))
     expect(sql).toContain('"id" integer')
   })
 
   test("uuid id strategy: postgres gen_random_uuid() default", async () => {
-    const sql = await generate(getTables, opts({ generateId: "uuid" }), { dialect: "postgresql" })
+    const sql = await generate(getTables, opts("postgres", { generateId: "uuid" }))
     expect(sql).toContain("gen_random_uuid()")
   })
 
   test("orders tables by `order` — post (order:2) before user (unordered)", async () => {
-    const sql = await generate(getTables, opts(), { dialect: "postgresql" })
+    const sql = await generate(getTables, opts("postgres"))
     const userIdx = sql.search(/create table "user"/i)
     const postIdx = sql.search(/create table "post"/i)
     expect(userIdx).toBeGreaterThanOrEqual(0)
     expect(postIdx).toBeGreaterThanOrEqual(0)
     expect(postIdx).toBeLessThan(userIdx)
+  })
+
+  test("throws when options.database is not an adapter instance", async () => {
+    await expect(
+      generate(getTables, { advanced: { database: {} } } as AdapterOptions, { format: "sql" }),
+    ).rejects.toThrow(/requires an adapter instance/)
   })
 })


### PR DESCRIPTION
Addresses #13 

## What's the Problem

unadapter provides `getMigrations()` for running live database migrations, but running it requires a database connection — `getMigrations()` calls `migrator.introspect()` against a live DB before it can diff or compile anything.

Library authors building on top of unadapter (e.g. better-auth) commonly want to offer a `generate` command in their own CLI:

```sh
npx my-lib generate
```

A `generate` command needs to emit the schema as a string **without** a live database. Today there is no public API for that, so library authors are pushed toward reimplementing the type-mapping logic themselves.

## Usage

```ts
import { generate } from "unadapter/generate"
import { kyselyAdapter } from "unadapter/adapters/kysely"

// In a "generate" CLI command — pass the same adapter you use at runtime:
const sql = await generate(getMyTables, {
  database: kyselyAdapter(db, { type: "postgres" }),
  advanced: { database: { /* useNumberId, generateId */ } },
}, { format: "sql" })
process.stdout.write(sql + "\n")
```

`generate()` is `async` (it reuses the async migration engine). The target dialect is
taken from the adapter's own config (e.g. `kyselyAdapter(db, { type })`). The id
strategy is read from `options.advanced.database` (`useNumberId`, `generateId`),
matching `getMigrations()`.