### PR TITLE
feat: support memory range where operators

### DIFF
--- a/src/adapters/memory/memory-adapter.ts
+++ b/src/adapters/memory/memory-adapter.ts
@@ -52,6 +52,14 @@ export function memoryAdapter<
               return record[field].startsWith(value)
             } else if (operator === "ends_with") {
               return record[field].endsWith(value)
+            } else if (operator === "gt") {
+              return record[field] > value
+            } else if (operator === "gte") {
+              return record[field] >= value
+            } else if (operator === "lt") {
+              return record[field] < value
+            } else if (operator === "lte") {
+              return record[field] <= value
             } else {
               return record[field] === value
             }

--- a/src/adapters/memory/memory-adapter.ts
+++ b/src/adapters/memory/memory-adapter.ts
@@ -52,14 +52,26 @@ export function memoryAdapter<
               return record[field].startsWith(value)
             } else if (operator === "ends_with") {
               return record[field].endsWith(value)
-            } else if (operator === "gt") {
-              return record[field] > value
-            } else if (operator === "gte") {
-              return record[field] >= value
-            } else if (operator === "lt") {
-              return record[field] < value
-            } else if (operator === "lte") {
-              return record[field] <= value
+            } else if (
+              operator === "gt" ||
+              operator === "gte" ||
+              operator === "lt" ||
+              operator === "lte"
+            ) {
+              // Range comparisons against null never match (SQL NULL semantics)
+              if (value === null) {
+                return false
+              }
+              switch (operator) {
+                case "gt":
+                  return record[field] > value
+                case "gte":
+                  return record[field] >= value
+                case "lt":
+                  return record[field] < value
+                case "lte":
+                  return record[field] <= value
+              }
             } else {
               return record[field] === value
             }

--- a/tests/adapter.memory.test.ts
+++ b/tests/adapter.memory.test.ts
@@ -1,6 +1,6 @@
 import type { BetterAuthOptions } from "./better-auth.schema.ts"
 import { createAdapter } from "../src/index.ts"
-import { describe } from "vitest"
+import { describe, expect, test } from "vitest"
 import { memoryAdapter } from "../src/adapters/memory/memory-adapter.ts"
 import { getAuthTables } from "./better-auth.schema.ts"
 import { runAdapterTest, runNumberIdAdapterTest } from "./test.ts"
@@ -49,5 +49,60 @@ describe("number Id Adapter Test", async () => {
         ...customOptions,
       })
     },
+  })
+})
+
+describe("memory adapter range filters", () => {
+  async function getRangeAdapter() {
+    return createAdapter<BetterAuthOptions>(getAuthTables, {
+      database: memoryAdapter({
+        user: [],
+        session: [],
+        account: [],
+      }),
+      user: {
+        additionalFields: {
+          sequenceId: {
+            type: "number",
+            required: true,
+            sortable: true,
+            fieldName: "sequenceId",
+          },
+        },
+      },
+    })
+  }
+
+  test("findMany applies numeric gt/gte/lt/lte comparisons", async () => {
+    const adapter = await getRangeAdapter()
+
+    for (const sequenceId of [1, 2, 3]) {
+      await adapter.create({
+        model: "user",
+        data: {
+          name: `event-${sequenceId}`,
+          email: `event-${sequenceId}@email.com`,
+          emailVerified: true,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+          sequenceId,
+        } as any,
+      })
+    }
+
+    async function findSequenceIds(operator: "gt" | "gte" | "lt" | "lte", value: number) {
+      const rows = await adapter.findMany({
+        model: "user",
+        where: [{ field: "sequenceId", operator, value }],
+        sortBy: { field: "sequenceId", direction: "asc" },
+      })
+
+      return rows.map((row: any) => row.sequenceId)
+    }
+
+    await expect(findSequenceIds("gt", 1)).resolves.toEqual([2, 3])
+    await expect(findSequenceIds("gte", 2)).resolves.toEqual([2, 3])
+    await expect(findSequenceIds("lt", 3)).resolves.toEqual([1, 2])
+    await expect(findSequenceIds("lte", 2)).resolves.toEqual([1, 2])
   })
 })


### PR DESCRIPTION
Closes #16 

## Summary

- Add `gt`, `gte`, `lt`, and `lte` support to memory adapter where filtering.
- Cover numeric range filtering in the memory adapter test suite.

## Why

The memory adapter previously treated numeric range operators as equality checks, so `findMany` returned incorrect results for filters such as `gt`, `gte`, `lt`, and `lte`.

This matches the documented shared `Where` API and brings memory adapter behavior in line with the other adapters.

## Testing

- `pnpm vitest run tests/adapter.memory.test.ts`
