### PR TITLE
feat: solidify SQL generate support

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 - [Installation](#-installation)
 - [Available Adapters](#-available-adapters)
 - [Getting Started](#-getting-started)
+- [Generate](#-generate)
 - [Migrations](#-migrations)
 - [API Reference](#-api-reference)
 - [Contributing](#-contributing)
@@ -1062,6 +1063,56 @@ await (await getMigrations({ database: sumakAdapter(db, { type: "postgres" }), .
 ```
 
 </details>
+
+## 🧬 Generate
+
+`generate()` compiles a `TablesSchema` into schema output that a library author
+can expose from their own CLI, such as `npx my-lib generate`.
+
+This is different from `runMigrations()`: generation does not inspect or modify
+a live database. It treats the database as empty and emits a full schema string.
+Applying that output remains the consumer's responsibility.
+
+Current scope:
+
+| Format  | Status | Notes                                                          |
+| ------- | ------ | -------------------------------------------------------------- |
+| SQL     | ✅     | Emits SQL DDL through adapters that implement `createMigrator` |
+| Prisma  | ❌     | Use Prisma Migrate / `prisma db push` for now                  |
+| Drizzle | ❌     | Use Drizzle Kit for now                                        |
+
+```typescript
+import { generate } from "unadapter/generate"
+import { kyselyAdapter } from "unadapter/kysely"
+
+export async function generateSchema() {
+  const sql = await generate(
+    getTables,
+    {
+      database: kyselyAdapter(db, { type: "postgres" }),
+      advanced: {
+        database: {
+          // useNumberId: true,
+          // generateId: "uuid",
+        },
+      },
+    },
+    { format: "sql" },
+  )
+
+  process.stdout.write(`${sql}\n`)
+}
+```
+
+The target SQL dialect is taken from the adapter configuration, for example
+`kyselyAdapter(db, { type: "postgres" })`. `generate()` currently requires an
+adapter instance whose adapter implements `createMigrator()`; Kysely, Knex, and
+Sumak support this path. The adapter can be backed by a driverless object if the
+underlying query builder can compile SQL without executing it.
+
+Adapters without migrators, such as Prisma, Drizzle, MongoDB, and Memory, return
+an explicit unsupported error for SQL generation. Their native schema tools
+remain the right way to apply schema changes.
 
 ## 🛠️ Migrations
 

--- a/src/db/get-migration.ts
+++ b/src/db/get-migration.ts
@@ -100,7 +100,7 @@ export async function getMigrations<T extends Record<string, any>>(
   const useNumberId = idStrategy === "number"
   const migratorOptions: MigratorOptions = { useNumberId, idStrategy }
 
-  const migrator = await resolveMigrator(config, getTables, logger)
+  const migrator = await resolveMigrator(config, getTables)
 
   const tableMetadata = migrationsConfig.skipIntrospect ? [] : await migrator.introspect()
 
@@ -251,7 +251,6 @@ export async function getMigrations<T extends Record<string, any>>(
 async function resolveMigrator<T extends Record<string, any>>(
   config: AdapterOptions<T>,
   getTables: (options: AdapterOptions<T>) => TablesSchema,
-  logger: ReturnType<typeof createLogger>,
 ): Promise<AdapterMigrator> {
   const db = config.database
 
@@ -261,11 +260,10 @@ async function resolveMigrator<T extends Record<string, any>>(
     if (instance.createMigrator) {
       return await instance.createMigrator()
     }
-    logger.error(
+    throw new Error(
       `[unadapter] adapter "${instance.id}" does not implement createMigrator. ` +
         `Use that adapter's native schema tooling, or pass a Kysely-compatible database to runMigrations().`,
     )
-    process.exit(1)
   }
 
   // Path 2: backwards-compatible Kysely autodetection (raw pool / dialect / { db, type } shapes).
@@ -273,12 +271,11 @@ async function resolveMigrator<T extends Record<string, any>>(
   const { createKyselyMigrator } = await import("../adapters/kysely/migrator.ts")
   const migrator = await createKyselyMigrator(config)
   if (!migrator) {
-    logger.error(
+    throw new Error(
       "[unadapter] no migrator could be resolved. Pass an AdapterInstance whose adapter " +
         "implements createMigrator, or a Kysely-compatible database (Kysely instance, Dialect, " +
         "better-sqlite3 Database, mysql2 pool, or pg Pool).",
     )
-    process.exit(1)
   }
   return migrator
 }

--- a/src/generate/index.ts
+++ b/src/generate/index.ts
@@ -22,8 +22,14 @@ export interface GenerateOptions {
 export async function generate<T extends Record<string, any>>(
   getTables: (options: AdapterOptions<T>) => TablesSchema,
   options: AdapterOptions<T>,
-  _generateOptions: GenerateOptions = {},
+  generateOptions: GenerateOptions = {},
 ): Promise<string> {
+  const format = (generateOptions as { format?: string }).format
+  if (format && format !== "sql") {
+    throw new Error(
+      `[unadapter] unsupported generate format "${format}". Only "sql" is currently supported.`,
+    )
+  }
   if (typeof options.database !== "function") {
     throw new Error(
       "[unadapter] generate() requires an adapter instance as options.database " +

--- a/tests/generate/generate.test.ts
+++ b/tests/generate/generate.test.ts
@@ -3,6 +3,7 @@ import type { AdapterOptions, TablesSchema } from "../../src/types/index.ts"
 import { Kysely, MysqlDialect, PostgresDialect, SqliteDialect } from "kysely"
 import { describe, expect, test } from "vitest"
 import { kyselyAdapter } from "../../src/adapters/kysely/kysely-adapter.ts"
+import { memoryAdapter } from "../../src/adapters/memory/memory-adapter.ts"
 import { generate } from "../../src/generate/index.ts"
 
 const tables: TablesSchema = {
@@ -51,6 +52,28 @@ function opts(
   return { database: adapterFor(type), advanced: { database: advancedDb } } as AdapterOptions
 }
 
+function adapterWithThrowingIntrospection() {
+  return () => ({
+    id: "throwing-introspection",
+    createMigrator: () => ({
+      introspect: async () => {
+        throw new Error("introspection should not run during generate")
+      },
+      createTable: async () => {},
+      addColumn: async () => {},
+      resolveType: () => "text",
+      matchType: () => true,
+      compileCreateTable: (table, idColumn, fields) => {
+        const columns = [
+          `"id" ${idColumn.type} primary key`,
+          ...Object.entries(fields).map(([name, column]) => `"${name}" ${column.type}`),
+        ]
+        return `create table "${table}" (${columns.join(", ")})`
+      },
+    }),
+  })
+}
+
 describe("generate() — offline SQL schema", () => {
   test("postgres: text PK, jsonb, timestamp default, FK, index", async () => {
     const sql = await generate(getTables, opts("postgres"), { format: "sql" })
@@ -97,5 +120,28 @@ describe("generate() — offline SQL schema", () => {
     await expect(
       generate(getTables, { advanced: { database: {} } } as AdapterOptions, { format: "sql" }),
     ).rejects.toThrow(/requires an adapter instance/)
+  })
+
+  test("does not call live introspection", async () => {
+    const sql = await generate(getTables, {
+      database: adapterWithThrowingIntrospection(),
+    } as AdapterOptions)
+
+    expect(sql).toMatch(/create table "user"/i)
+    expect(sql).toMatch(/create table "post"/i)
+  })
+
+  test("throws an actionable error for adapters without migrators", async () => {
+    await expect(
+      generate(getTables, {
+        database: memoryAdapter({ user: [], post: [] }),
+      } as AdapterOptions),
+    ).rejects.toThrow(/adapter "memory" does not implement createMigrator/)
+  })
+
+  test("throws an actionable error for unsupported formats", async () => {
+    await expect(
+      generate(getTables, opts("postgres"), { format: "prisma" as any }),
+    ).rejects.toThrow(/unsupported generate format "prisma"/)
   })
 })


### PR DESCRIPTION
Adresses #13 

## Summary

Solidifies the existing SQL `generate()` path so library authors can confidently expose commands like `npx my-lib generate` for schema output.

This PR documents `generate()` as an offline SQL DDL generation API, adds clearer runtime errors for unsupported cases, and adds regression coverage for the no-introspection behavior.

## Changes

- Documents the current `generate()` scope in the README:
  - SQL DDL generation is supported.
  - Prisma and Drizzle generation are not supported yet.
  - Applying generated schema output remains the consumer's responsibility.
- Adds runtime validation for unsupported `generate()` formats.
- Changes migrator resolution failures from `process.exit(1)` to thrown errors so library CLIs can catch and surface them.
- Removes the now-unused `logger` parameter from `resolveMigrator()` because migrator resolution failures are returned as catchable errors instead of being logged and followed by process exit.
- Adds tests for:
  - SQL generation without live introspection.
  - adapters that do not implement `createMigrator()`.
  - unsupported generate formats.

## Why

`generate()` is intended to support library authors building their own CLI generation flow on top of unadapter. For that use case, the API should be explicit about what it supports and should fail with catchable, actionable errors rather than exiting the process.

This keeps the current scope conservative: unadapter emits SQL DDL through adapters with migrators, while Prisma and Drizzle users should continue using their native schema/migration tooling for now.

## Validation

- `pnpm lint`
- `pnpm typecheck`
- `pnpm exec vitest run tests/generate/generate.test.ts --reporter verbose`